### PR TITLE
Fix deprecated QByteArray += QString

### DIFF
--- a/bencode.cpp
+++ b/bencode.cpp
@@ -515,7 +515,7 @@ QByteArray Bencode::toRaw(const Bencode *bencode)
 
     case String: {
         QByteArray ba = bencode->_string;
-        res += QString::number(ba.size());
+        res += QString::number(ba.size()).toUtf8();
         res += ':';
         res += ba;
 #ifdef DEBUG
@@ -548,7 +548,7 @@ QByteArray Bencode::toRaw(const Bencode *bencode)
 #ifdef DEBUG
             qDebug() << "encode" << fromRawString(key) << "item";
 #endif
-            res += QString::number(key.size());
+            res += QString::number(key.size()).toUtf8();
             res += ':';
             res += key;
 

--- a/bencode.cpp
+++ b/bencode.cpp
@@ -515,7 +515,7 @@ QByteArray Bencode::toRaw(const Bencode *bencode)
 
     case String: {
         QByteArray ba = bencode->_string;
-        res += QString::number(ba.size()).toUtf8();
+        res += QString::number(ba.size()).toLatin1();
         res += ':';
         res += ba;
 #ifdef DEBUG
@@ -548,7 +548,7 @@ QByteArray Bencode::toRaw(const Bencode *bencode)
 #ifdef DEBUG
             qDebug() << "encode" << fromRawString(key) << "item";
 #endif
-            res += QString::number(key.size()).toUtf8();
+            res += QString::number(key.size()).toLatin1();
             res += ':';
             res += key;
 


### PR DESCRIPTION
Fixes the following deprecation warnings:

```
/mnt/data/.cache/yay/torrent-file-editor-qt5-git/src/torrent-file-editor/bencode.cpp:518:41: error: ‘QByteArray& QByteArray::operator+=(const QString&)’ is deprecated: Use QString's toUtf8(), toLatin1() or toLocal8Bit() [-Werror=deprecated-declarations]
  518 |         res += QString::number(ba.size());
      |                                         ^
```

```
/mnt/data/.cache/yay/torrent-file-editor-qt5-git/src/torrent-file-editor/bencode.cpp:551:46: error: ‘QByteArray& QByteArray::operator+=(const QString&)’ is deprecated: Use QString's toUtf8(), toLatin1() or toLocal8Bit() [-Werror=deprecated-declarations]
  551 |             res += QString::number(key.size());
      |                                              ^
```

Both are fixed by doing what the deprecated operator already does: Append `.toUtf8()`, so instead of
```
QByteArray &QByteArray::operator+=(const QString &s)
```
instead
```
QByteArray &QByteArray::operator+=(const QByteArray &a)
```
is used, which is not deprecated.