### PR TITLE
Add "Source (optional)" field to Main tab

### DIFF
--- a/bencodemodel.cpp
+++ b/bencodemodel.cpp
@@ -161,6 +161,31 @@ bool BencodeModel::privateTorrent() const
     }
 }
 
+void BencodeModel::setSource(const QString &source)
+{
+    if (source.isEmpty() && _bencode && _bencode->child("info") && _bencode->child("info")->child("source")) {
+        removeRow(_bencode->child("info")->child("source")->row(), nodeToIndex(_bencode->child("info")));
+        if (!_bencode->child("info")->childCount()) {
+            removeRow(_bencode->child("info")->row(), nodeToIndex(_bencode));
+        }
+    } else if (!source.isEmpty()) {
+        emit layoutAboutToBeChanged();
+        _bencode->checkAndCreate(Bencode::Type::Dictionary, "info")
+            ->checkAndCreate(Bencode::Type::String, "source")
+            ->setString(fromUnicode(source));
+        emit layoutChanged();
+    }
+}
+
+QString BencodeModel::source() const
+{
+    if (_bencode && _bencode->child("info") && _bencode->child("info")->child("source")) {
+        return toUnicode(_bencode->child("info")->child("source")->string());
+    } else {
+        return QString();
+    }
+}
+
 void BencodeModel::setUrl(const QString &url)
 {
     if (url.isEmpty() && _bencode && _bencode->child("publisher-url")) {

--- a/bencodemodel.h
+++ b/bencodemodel.h
@@ -48,6 +48,9 @@ public:
     void setPrivateTorrent(bool privateTorrent);
     bool privateTorrent() const;
 
+    void setSource(const QString &source);
+    QString source() const;
+
     void setUrl(const QString &url);
     QString url() const;
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -665,6 +665,7 @@ void MainWindow::updateBencodeFromSimple()
     _bencodeModel->setCreatedBy(ui->leCreatedBy->text());
     _bencodeModel->setCreationTime(ui->dateCreated->dateTime());
     _bencodeModel->setPrivateTorrent(ui->chkPrivateTorrent->isChecked());
+    _bencodeModel->setSource(ui->leSource->text());
     ui->leHash->setText(_bencodeModel->hash());
     ui->leMagnetLink->setText(_bencodeModel->magnetLink());
 }
@@ -1208,6 +1209,7 @@ void MainWindow::updateSimple()
 
     ui->dateCreated->setDateTime(_bencodeModel->creationTime());
     ui->chkPrivateTorrent->setChecked(_bencodeModel->privateTorrent());
+    ui->leSource->setText(_bencodeModel->source());
     ui->pteTrackers->setPlainText(_bencodeModel->trackers().join(QStringLiteral("\n")));
     ui->leHash->setText(_bencodeModel->hash());
     ui->leMagnetLink->setText(_bencodeModel->magnetLink());

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -299,6 +299,16 @@ SPDX-License-Identifier: GPL-3.0-or-later
               </property>
              </widget>
             </item>
+            <item row="6" column="0">
+             <widget class="QLabel" name="label_19">
+              <property name="text">
+               <string>Source</string>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1">
+             <widget class="QLineEdit" name="leSource"/>
+            </item>
             <item row="12" column="0">
              <spacer name="verticalSpacer">
               <property name="orientation">
@@ -998,6 +1008,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
   <tabstop>leCreatedBy</tabstop>
   <tabstop>dateCreated</tabstop>
   <tabstop>chkPrivateTorrent</tabstop>
+  <tabstop>leSource</tabstop>
   <tabstop>pteComment</tabstop>
   <tabstop>pteTrackers</tabstop>
   <tabstop>btnAbout</tabstop>
@@ -1535,6 +1546,22 @@ SPDX-License-Identifier: GPL-3.0-or-later
     <hint type="sourcelabel">
      <x>244</x>
      <y>306</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>4</x>
+     <y>359</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>leSource</sender>
+   <signal>textEdited(QString)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>updateBencodeFromSimple()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>467</x>
+     <y>341</y>
     </hint>
     <hint type="destinationlabel">
      <x>4</x>


### PR DESCRIPTION
This adds a Source (optional) field to the main tab.
I was sick of needing to manually go to the RAW tab to modify the torrent source for private torrents.
If the field is empty the property is omitted.
