### PR TITLE
Guard array/object allocation size against integer overflow in json-parser.c

### DIFF
--- a/json-parser.c
+++ b/json-parser.c
@@ -149,6 +149,14 @@ static int new_value (json_state * state,
             if (value->u.array.length == 0)
                break;
 
+            /* Division by a runtime length, not a compile-time constant, so this
+               remains a real check instead of folding to a compile-time truth on
+               platforms where length can never reach SIZE_MAX / sizeof(entry). */
+            if (sizeof (json_value *) > ((size_t) -1) / value->u.array.length)
+            {
+               return 0;
+            }
+
             if (! (value->u.array.values = (json_value **) json_alloc
                (state, value->u.array.length * sizeof (json_value *), 0)) )
             {
@@ -162,6 +170,11 @@ static int new_value (json_state * state,
 
             if (value->u.object.length == 0)
                break;
+
+            if (sizeof (*value->u.object.values) > ((size_t) -1) / value->u.object.length)
+            {
+               return 0;
+            }
 
             values_size = sizeof (*value->u.object.values) * value->u.object.length;
 


### PR DESCRIPTION
This patch was written by Claude Sonnet 5 (Anthropic); I reviewed the change and the reasoning before submitting.

json-parser.c vendors the json-parser library. In new_value(), the array and object branches compute the allocation size as length * sizeof(entry) and pass that straight to json_alloc() with no overflow check. Where size_t is 32-bit, a document with a large enough array or object length wraps the multiplication, json_alloc() ends up allocating a buffer far smaller than length actually needs, and the parser then writes length entries into it, a heap buffer overflow.

Both branches are guarded by dividing instead of multiplying, so the check itself cannot overflow: sizeof(entry) > SIZE_MAX / length means length * sizeof(entry) would overflow. The division uses the runtime length rather than folding sizeof(entry) against a literal constant, since comparing length (an unsigned int) directly against ULONG_MAX / sizeof(entry) is provably unreachable on LP64 platforms where size_t is 64-bit, and clang flags that form as a tautological comparison. This form stays a real check on any platform, including where size_t is narrower than the length field.

Verified the file still compiles cleanly with clang -Wall -Wextra (no new warnings beyond two pre-existing unused-parameter ones) and that normal array and object parsing is unaffected, checked with a small test harness against json_parse() on both types.